### PR TITLE
feat: disable markup by default for torrent details labels #71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Support for Textual v3 [#71](https://github.com/anlar/tewi/issues/71)
+
 ### Removed
 
 ## [0.7.0] - 2025-06-04 - Red Eyed Rabbit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = { file = "LICENSE.txt" }
 requires-python = ">=3.10"
 dependencies = [
-  "textual >= 0.83.0, <= 1.0.0",
+  "textual >= 0.83.0",
   "transmission-rpc >= 7.0.11",
   "geoip2fast >= 1.2.2",
   "pyperclip >= 1.9.0"

--- a/src/tewi/app.py
+++ b/src/tewi/app.py
@@ -248,6 +248,10 @@ class ReactiveLabel(Label):
 
     name = reactive(None, layout=True)
 
+    def __init__(self, *args, markup=False, **kwargs):
+        super().__init__(*args, markup=markup, **kwargs)
+        self.markup = False
+
     def render(self):
         if self.name:
             return self.name

--- a/src/tewi/app.py
+++ b/src/tewi/app.py
@@ -947,7 +947,7 @@ class TorrentItemOneline(TorrentItem):
 
     @log_time
     def compose(self) -> ComposeResult:
-        yield Label(self.t_name, id="name")
+        yield Label(self.t_name, id="name", markup=False)
 
         with Grid(id="speed"):
             yield ReactiveLabel(id="stats").data_bind(
@@ -981,7 +981,7 @@ class TorrentItemCompact(TorrentItem):
 
     @log_time
     def compose(self) -> ComposeResult:
-        yield Label(self.t_name, id="name")
+        yield Label(self.t_name, id="name", markup=False)
 
         with Grid(id="speed"):
             yield ReactiveLabel(id="stats").data_bind(
@@ -1004,7 +1004,7 @@ class TorrentItemCard(TorrentItem):
 
     @log_time
     def compose(self) -> ComposeResult:
-        yield Label(self.t_name, id="name")
+        yield Label(self.t_name, id="name", markup=False)
 
         with Grid(id="speed"):
             yield Static(" ↑ ")


### PR DESCRIPTION
Textual v2 introduced markup for labels which is enabled by
default. Need to disable it to handle torrent names including
symbols like [ and ].

- disable markup for torrent name in all card types
- disable markup in ReactiveLabel